### PR TITLE
Fixes bug Empty subclient results in a KeyError exception #136 

### DIFF
--- a/cvpysdk/subclients/vssubclient.py
+++ b/cvpysdk/subclients/vssubclient.py
@@ -623,7 +623,10 @@ class VirtualServerSubclient(Subclient):
             else:
                 display_name = child['displayName']
                 content_type = VSAObjects(child['type']).name
-                vm_id = child['name']
+                if 'name' in child:
+                    vm_id = child['name']
+                else:
+                    return content_list
                 temp_dict = {
                     'equal_value': child['equalsOrNotEquals'],
                     'allOrAnyChildren': child['allOrAnyChildren'],


### PR DESCRIPTION
Fixes bug Empty subclient results in a KeyError exception #136 by checking if the key is defined.

The error occurs when an empty subclient is broswed with browse()