### PR TITLE
Fix Record Type to Lowercase

### DIFF
--- a/cvpysdk/credential_manager.py
+++ b/cvpysdk/credential_manager.py
@@ -99,7 +99,7 @@ class Credentials(object):
         self._credentials = self._get_credentials()
         self.record_type = {
             'windows': 1,
-            'Linux': 2
+            'linux': 2
         }
 
     def __str__(self):


### PR DESCRIPTION
Fix Dict record "self.record_type" to lower case, since we check the provided record value against its lower case value.

With the current implementation, it fails when we create a credentials.

```
com.credentials.add(
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/cvpysdk/credential_manager.py", line 243, in add
    "recordType": self.record_type[record_type.lower()],
                  ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
KeyError: 'linux'
```

After changes, it goes though successfully.